### PR TITLE
Set utf8 flag on all returned values

### DIFF
--- a/lib/Escape/Houdini.xs
+++ b/lib/Escape/Houdini.xs
@@ -22,6 +22,8 @@
 	                                                           \
 	    result = newSVpvn( buffer.ptr, buffer.size );          \
 	    gh_buf_free(&buffer);                                  \
+	    SvUTF8_on(result);                                     \
+                                                             \
 	    return result;                                         \
 	}
 

--- a/t/utf8.t
+++ b/t/utf8.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 9;
+use Escape::Houdini qw/ :all /;
+use Encode;
+
+{
+	my $src = '<div class="❤">foo</div>';
+	my $was_flag = Encode::is_utf8( $src );
+
+	my $dst = escape_html $src; 
+	my $is_flag = Encode::is_utf8( $dst );
+
+	ok $was_flag == $is_flag, "Utf8 flag is preserved after html escaping";
+}
+
+{
+	my $src = '&lt;div class=&quot;❤&quot;&gt;foo&lt;&#47;div&gt;';
+	my $was_flag = Encode::is_utf8( $src );
+
+	my $dst = unescape_html $src; 
+	my $is_flag = Encode::is_utf8( $dst );
+
+	ok $was_flag == $is_flag, "Utf8 flag is preserved after html unescaping";
+}
+
+{
+	my $src = "http://☃.net";
+	my $was_flag = Encode::is_utf8( $src );
+
+	for my $sub (qw( escape_url escape_uri escape_href )) {
+		no strict 'refs';
+		my $dst = "$sub"->($src);
+		my $is_flag = Encode::is_utf8( $dst );
+		ok $was_flag == $is_flag, "Utf8 flag is preserved after $sub";
+	}
+}
+
+{
+	my $src = 'http%3A%2F%2F☃.net';
+	my $was_flag = Encode::is_utf8( $src );
+
+	for my $sub (qw( unescape_url unescape_uri )) {
+		no strict 'refs';
+		my $dst = "$sub"->($src);
+		my $is_flag = Encode::is_utf8( $dst );
+		ok $was_flag == $is_flag, "Utf8 flag is preserved after $sub";
+	}
+}
+
+{
+	my $src = "foo['❤']\nbar";
+	my $was_flag = Encode::is_utf8( $src );
+
+	for my $sub (qw( escape_js )) {
+		no strict 'refs';
+		my $dst = "$sub"->($src);
+		my $is_flag = Encode::is_utf8( $dst );
+		ok $was_flag == $is_flag, "Utf8 flag is preserved after $sub";
+	}
+}
+
+{
+	my $src = q|foo['❤']\nbar|;
+	my $was_flag = Encode::is_utf8( $src );
+
+	for my $sub (qw( unescape_js )) {
+		no strict 'refs';
+		my $dst = "$sub"->($src);
+		my $is_flag = Encode::is_utf8( $dst );
+		ok $was_flag == $is_flag, "Utf8 flag is preserved after $sub";
+	}
+}


### PR DESCRIPTION
From houdini readme:
Houdini parses only UTF-8 strings, and generates only UTF-8 strings. If you are using another encoding, you should probably transcode before passing the buffer to Houdini.

However, return values from Escape-Houldini come with unset utf8 flag. This can lead to unexpected double utf8 encoding, as it was for me in Template::Moustache.

Therefore I propose to set utf8 flag on all return values, see patch.